### PR TITLE
Clear animation (pose) when importing from meddle, but preserve scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## ⚡ Whats new ?
 
 - ✔ **Pins** – [Pins can now be fully disabled if you run into issues (requires a blender restart)](https://github.com/MekuMaki/Mektools/wiki/Pins-Panel)
-- ✔ **Added Projection Plane to CTRL + A > Curve**.  
+- ✔ **Added Projection Plane to CTRL + A > Curve** -> [Wiki page](https://github.com/MekuMaki/Mektools/wiki/OPP).  
   
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <p>
     <img src="https://img.shields.io/github/v/release/MekuMaki/Mektools?label=Mektools&color=blue">
     <img src="https://img.shields.io/badge/Blender-4.4%2B-orange">
-    <img src="https://img.shields.io/badge/Meddle-0.24%2B-blue">
+    <img src="https://img.shields.io/badge/Meddle-0.29%2B-blue">
     <img src="https://img.shields.io/github/license/MekuMaki/Mektools">
   </p>
   <p>🚀 The all-in-one Blender extension for importing, posing, and exporting FFXIV characters.</p>
@@ -13,10 +13,8 @@
 
 ## ⚡ Whats new ?
 
-- ✔ **Pins** – [Experimental Feature](https://github.com/MekuMaki/Mektools/wiki/Pins-Panel)
-- ✔ **Minor import Adjustments**.  
-- ✔ **Bug Fixes**.  
-- ✔ **Recommended version updates, see below**. 
+- ✔ **Pins** – [Pins can now be fully disabled if you run into issues (requires a blender restart)](https://github.com/MekuMaki/Mektools/wiki/Pins-Panel)
+- ✔ **Added Projection Plane to CTRL + A > Curve**.  
   
 
 ---
@@ -38,7 +36,7 @@
 | **Software** | **Recommended Version** |
 |-------------|----------------------|
 | **Blender** | 4.4+ |
-| **Meddle**  | 0.24+ |
+| **Meddle**  | 0.29+ |
 
 > **You can use newer versions, but these are the tested ones.**  
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ---
 
 ## ⚡ Whats new ?
-
+- ✔ **Anim Export Y-Up = False** - this is a temporary fix and will make it that you can export Mekrig anims with the button but not Vanilla armature anymore. 
 - ✔ **Pins** – [Pins can now be fully disabled if you run into issues (requires a blender restart)](https://github.com/MekuMaki/Mektools/wiki/Pins-Panel)
 - ✔ **Added Projection Plane to CTRL + A > Curve** -> [Wiki page](https://github.com/MekuMaki/Mektools/wiki/OPP).  
   

--- a/mektools/__init__.py
+++ b/mektools/__init__.py
@@ -35,7 +35,7 @@ from .handler import (
 bl_info = {
     "name": "MekTools",
     "author": "MekuMaki & Shino Mythmaker",
-    "version": (1,8,4),
+    "version": (1,8,5),
     "blender": (4,2,0),
     "description": "A collection of tools for working with FFXIV models in Blender.",
     "category": "Mektools",

--- a/mektools/blender_manifest.toml
+++ b/mektools/blender_manifest.toml
@@ -1,10 +1,10 @@
 schema_version = "0.0.1"
 
 id = "mektools"
-version = "1.8.4"
+version = "1.8.5"
 name = "MekTools"
 feature_patch = "0"
-feature_name = "dev"
+feature_name = "main"
 tagline = "This is another extension"
 maintainer = "MekuMaki, Shino Mythmaker"
 type = "add-on"

--- a/mektools/manifest.json
+++ b/mektools/manifest.json
@@ -2,14 +2,14 @@
   "id": "MekTools",
   "name": "MekTools",
   "type": "extensions",
-"version": [1, 8, 4],
+"version": [1, 8, 5],
   "blender": [4, 2, 0],
   "author": "MekuMaki & Shino Mythmaker",
   "category": "Mektools",
   "description": "A collection of tools for working with FFXIV models in Blender.",
   "tags": ["modeling", "animation", "import-export"],
   "path": "MekTools",
-"feature_name": "dev",
+"feature_name": "main",
 "feature_patch": 0,
   "location": "View3D > Mektools Tab"
 }


### PR DESCRIPTION
Feel free to tweak, would probably be best to include the re-apply of scaling as a toggle instead of default but this should mean that when exporting from meddle in any pose mode it should still import fine